### PR TITLE
Adds UTM params to seasons URL

### DIFF
--- a/src/lib/productURLFromSlug.ts
+++ b/src/lib/productURLFromSlug.ts
@@ -1,2 +1,2 @@
 export const productURLFromSlug = (slug: string) =>
-  `${process.env.FLARE_ORIGIN}/product/${slug}`;
+  `${process.env.FLARE_ORIGIN}/product/${slug}?utm_source=${window.location.hostname}&utm_campaign=trywithseasons&utm_medium=widget`;


### PR DESCRIPTION
Adds params to `/product/<id>`
- `utm_campaign` = trywithseasons
- `utm_source` = hostname of the website (e.g. `judy-turner.com`)
- `utm_medium` = widget